### PR TITLE
add typescript definition and fix this is undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+export interface JSImageCompressorOptions<T extends File = File> {
+  file: File;
+  quality?: number;
+  mimeType?: string;
+  maxWidth?: number;
+  maxHeight?: number;
+  width?: number;
+  height?: number;
+  minWidth?: number;
+  minHeight?: number;
+  convertSize?: number;
+  loose?: boolean;
+  redressOrientation?: boolean;
+  beforeCompress?: (file: T) => void;
+  success?: (file: T) => void;
+  error?: (msg: string) => void;
+}
+export default class JSImageCompressor<T extends File = File> {
+  constructor(options: JSImageCompressorOptions<T>) {}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ _proto.init = function () {
         _this.rendCanvas()
       }
     },
-    _this.error
+    _this.error.bind(_this)
   )
 }
 


### PR DESCRIPTION
Thanks for this package. 
I found issues when I using this package. So I want to fix them.
In the first commit, I add a typescript definition for this package, then we don't need to write a extra definition file for this package.
In the second commit, I fix a bug in the error callback. When Image onerror method call, "this.options" in error method will be undefined (Because we call it in onerror callback). So I add a `.bind(_this)` to fix this bug.   